### PR TITLE
Adds a --json flag to gslc

### DIFF
--- a/src/gslc/commandConfig.fs
+++ b/src/gslc/commandConfig.fs
@@ -127,6 +127,10 @@ let cmdLineArgs = [
     {arg = "name2id"; param = ["outfile"]; alias = [];
      desc = "filename/path for name2id mapping in rycody output.\nDefault is projname.name2id.txt";
      proc = fun p opts -> {opts with name2IdPath = Some(p.[0])} };
+
+    {arg = "json"; param = ["outfile"]; alias = [];
+     desc = "write a json file format for the assembly results";
+     proc = fun p opts -> {opts with jsonOut = Some(p.[0])} };
 ]
 
 // TODO: add command aliases
@@ -179,6 +183,7 @@ let defaultOpts:ParsedOptions =
     lexOnly = false
     refList = false
     refDump = None
+    jsonOut = None
     }
 
 /// Parse a command line arguments.  Return the parsed options and the list of

--- a/src/gslc/commonTypes.fs
+++ b/src/gslc/commonTypes.fs
@@ -31,6 +31,7 @@ type ParsedOptions =
     lexOnly: bool
     refList : bool
     refDump : string option
+    jsonOut: string option
     }
 
 type DNAIntervalType = ANNEAL | RYSELINKER | AMP | SANDWICH 

--- a/src/gslc/gslc.fsproj
+++ b/src/gslc/gslc.fsproj
@@ -50,7 +50,6 @@
     </Otherwise>
   </Choose>
   <Import Project="$(FSharpTargetsPath)" Condition="Exists('$(FSharpTargetsPath)')" />
-  <Import Project="c:\seq\GSL\packages\FsLexYacc.6.1.0\build\FsLexYacc.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
@@ -89,6 +88,7 @@
     <Compile Include="alleleSwapPluginDefs.fs" />
     <Compile Include="alleleSwaps.fs" />
     <Compile Include="ape.fs" />
+    <Compile Include="jsonAssembly.fs" />
     <Compile Include="cloneManager.fs" />
     <Compile Include="thumper.fs" />
     <Compile Include="l2PluginDefs.fs" />

--- a/src/gslc/gslcProcess.fs
+++ b/src/gslc/gslcProcess.fs
@@ -314,7 +314,7 @@ let writeOutput
 
     match opts.jsonOut with
     | None -> ()
-    | Some(prefix) -> dumpJsonAssemblies prefix tweakedTree
+    | Some(outFile) -> dumpJsonAssemblies outFile tweakedTree
 
     match opts.thumperOut with
     | None -> ()

--- a/src/gslc/gslcProcess.fs
+++ b/src/gslc/gslcProcess.fs
@@ -22,6 +22,7 @@ open thumper // Thumper output formats, dumping etc
 open ryse    // RYSE architecture
 open cloneManager
 open ape
+open jsonAssembly
 open DnaCreation
 open PrimerCreation
 open dumpFlat
@@ -310,6 +311,10 @@ let writeOutput
     match opts.cmOut with
     | None -> ()
     | Some(path,tag) -> dumpCM path tag tweakedTree primers
+
+    match opts.jsonOut with
+    | None -> ()
+    | Some(prefix) -> dumpJsonAssemblies prefix tweakedTree
 
     match opts.thumperOut with
     | None -> ()

--- a/src/gslc/jsonAssembly.fs
+++ b/src/gslc/jsonAssembly.fs
@@ -1,0 +1,88 @@
+﻿module jsonAssembly
+
+open System.IO
+open System.Text
+open System
+open commonTypes
+open constants
+open Amyris.Bio.utils
+open parseTypes
+open shared
+open Newtonsoft.Json
+open System.Collections.Generic
+
+/// Represents one piece of DNA for assembly, capturing its origins and relevant details
+type DNASliceJson =
+   {id: string; 
+    extId: string; 
+    dna: string;  
+    sourceChr: string; 
+    sourceFr: string; 
+    sourceTo: string; 
+    sourceFwd: bool;
+    destFr: string; 
+    destTo: string;
+    destFwd: bool; 
+    amplified: bool; 
+    sliceName: string;
+    sliceType: string;
+    breed: string;
+    description: string ; 
+}
+
+type AssemblyOutJson = 
+    { id: string;
+    name: string;
+    dnaSlices: DNASliceJson list;
+}
+
+///  Write out a JSON file representing the output assembly list to a given path. 
+let dumpJsonAssemblies (outFile:string) (assemblies : AssemblyOut list) =
+
+    use outF = new StreamWriter(outFile)
+    let assemblyHash =
+        assemblies 
+            |> List.map(fun a ->
+            { id = a.id.Value.ToString(); name = a.name.ToString();
+            dnaSlices = (a.dnaParts |> List.map(fun d ->
+            { id = (match d.id with | None -> "0" | _ -> d.id.Value.ToString());
+            extId = "";
+            dna = String.Join("", d.dna);
+            sourceChr = d.sourceChr;
+            sourceFr = d.sourceFr.ToString();
+            sourceTo = d.sourceTo.ToString();
+            sourceFwd = d.sourceFwd;
+            destFr = d.destFr.ToString();
+            destTo = d.destTo.ToString();
+            destFwd = d.destFwd;
+            amplified = d.amplified;
+            sliceName = d.sliceName.ToString();
+            sliceType = 
+                (match d.sliceType with
+                    | REGULAR -> "REGULAR"
+                    | MARKER -> "MARKER"
+                    | LINKER -> "LINKER"
+                    | INLINEST -> "INLINE"
+                    | FUSIONST ->"FUSION");
+            breed = 
+                (match d.breed with 
+                    | B_PROMOTER -> "B_PROMOTER"
+                    | B_TERMINATOR -> "B_TERMINATOR"
+                    | B_MARKER -> "B_MARKER"
+                    | B_FUSABLEORF -> "B_FUSABLEORF"
+                    | B_UPSTREAM -> "B_UPSTREAM"
+                    | B_DOWNSTREAM -> "B_DOWNSTREAM"
+                    | B_GST -> "B_GST"
+                    | G_M -> "G_M"
+                    | G_STOP -> "G_STOP"
+                    | B_GS -> "B_GS"
+                    | B_INLINE -> "B_INLINE"
+                    | B_X -> "B_X"
+                    | B_VIRTUAL -> "B_VIRTUAL"
+                    | B_LINKER -> "B_LINKER" );
+            description = d.description.ToString()}));
+            })
+    
+    let newstring:string = Newtonsoft.Json.JsonConvert.SerializeObject(assemblyHash, Formatting.Indented)
+    outF.WriteLine(newstring)
+

--- a/src/gslc/jsonAssembly.fs
+++ b/src/gslc/jsonAssembly.fs
@@ -11,7 +11,7 @@ open shared
 open Newtonsoft.Json
 open System.Collections.Generic
 
-/// Represents one piece of DNA for assembly, capturing its origins and relevant details
+/// A few key fields of a DNA slice for JSON representation.
 type DNASliceJson =
    {id: string; 
     extId: string; 
@@ -30,6 +30,7 @@ type DNASliceJson =
     description: string ; 
 }
 
+/// A few key fields of Assembly output for JSON representation.
 type AssemblyOutJson = 
     { id: string;
     name: string;

--- a/src/gslc/jsonAssembly.fs
+++ b/src/gslc/jsonAssembly.fs
@@ -32,10 +32,35 @@ type DNASliceJson =
 
 /// A few key fields of Assembly output for JSON representation.
 type AssemblyOutJson = 
-    { id: string;
+    {id: string;
     name: string;
     dnaSlices: DNASliceJson list;
 }
+
+let formatST (s:SliceType) = 
+    match s with 
+    | REGULAR -> "REGULAR"
+    | MARKER -> "MARKER"
+    | LINKER -> "LINKER"
+    | INLINEST -> "INLINE"
+    | FUSIONST ->"FUSION"
+
+let formatBreed (b:Breed) = 
+    match b with 
+    | B_PROMOTER -> "B_PROMOTER"
+    | B_TERMINATOR -> "B_TERMINATOR"
+    | B_MARKER -> "B_MARKER"
+    | B_FUSABLEORF -> "B_FUSABLEORF"
+    | B_UPSTREAM -> "B_UPSTREAM"
+    | B_DOWNSTREAM -> "B_DOWNSTREAM"
+    | B_GST -> "B_GST"
+    | G_M -> "G_M"
+    | G_STOP -> "G_STOP"
+    | B_GS -> "B_GS"
+    | B_INLINE -> "B_INLINE"
+    | B_X -> "B_X"
+    | B_VIRTUAL -> "B_VIRTUAL"
+    | B_LINKER -> "B_LINKER" 
 
 ///  Write out a JSON file representing the output assembly list to a given path. 
 let dumpJsonAssemblies (outFile:string) (assemblies : AssemblyOut list) =
@@ -43,47 +68,27 @@ let dumpJsonAssemblies (outFile:string) (assemblies : AssemblyOut list) =
     use outF = new StreamWriter(outFile)
     let assemblyHash =
         assemblies 
-            |> List.map(fun a ->
-            { id = a.id.Value.ToString(); name = a.name.ToString();
-            dnaSlices = (a.dnaParts |> List.map(fun d ->
-            { id = (match d.id with | None -> "0" | _ -> d.id.Value.ToString());
-            extId = "";
-            dna = String.Join("", d.dna);
-            sourceChr = d.sourceChr;
-            sourceFr = d.sourceFr.ToString();
-            sourceTo = d.sourceTo.ToString();
-            sourceFwd = d.sourceFwd;
-            destFr = d.destFr.ToString();
-            destTo = d.destTo.ToString();
-            destFwd = d.destFwd;
-            amplified = d.amplified;
-            sliceName = d.sliceName.ToString();
-            sliceType = 
-                (match d.sliceType with
-                    | REGULAR -> "REGULAR"
-                    | MARKER -> "MARKER"
-                    | LINKER -> "LINKER"
-                    | INLINEST -> "INLINE"
-                    | FUSIONST ->"FUSION");
-            breed = 
-                (match d.breed with 
-                    | B_PROMOTER -> "B_PROMOTER"
-                    | B_TERMINATOR -> "B_TERMINATOR"
-                    | B_MARKER -> "B_MARKER"
-                    | B_FUSABLEORF -> "B_FUSABLEORF"
-                    | B_UPSTREAM -> "B_UPSTREAM"
-                    | B_DOWNSTREAM -> "B_DOWNSTREAM"
-                    | B_GST -> "B_GST"
-                    | G_M -> "G_M"
-                    | G_STOP -> "G_STOP"
-                    | B_GS -> "B_GS"
-                    | B_INLINE -> "B_INLINE"
-                    | B_X -> "B_X"
-                    | B_VIRTUAL -> "B_VIRTUAL"
-                    | B_LINKER -> "B_LINKER" );
-            description = d.description.ToString()}));
+        |> List.map(fun a ->
+            {id = a.id.Value.ToString(); name = a.name.ToString();
+            dnaSlices = (a.dnaParts 
+                |> List.map(fun d ->
+                    {id = (match d.id with | None -> "0" | Some id -> id.ToString());
+                    extId = "";
+                    dna = String.Join("", d.dna);
+                    sourceChr = d.sourceChr;
+                    sourceFr = d.sourceFr.ToString();
+                    sourceTo = d.sourceTo.ToString();
+                    sourceFwd = d.sourceFwd;
+                    destFr = d.destFr.ToString();
+                    destTo = d.destTo.ToString();
+                    destFwd = d.destFwd;
+                    amplified = d.amplified;
+                    sliceName = d.sliceName.ToString();
+                    sliceType = (formatST d.sliceType);
+                    breed = (formatBreed d.breed);
+                    description = d.description.ToString()})
+                );
             })
     
-    let newstring:string = Newtonsoft.Json.JsonConvert.SerializeObject(assemblyHash, Formatting.Indented)
-    outF.WriteLine(newstring)
-
+    let jsonFileString:string = Newtonsoft.Json.JsonConvert.SerializeObject(assemblyHash, Formatting.Indented)
+    outF.WriteLine(jsonFileString)


### PR DESCRIPTION
Adds a --json flag to gslc. Writes out a JSON representation of the assembly results.
Used by Autodesk's GSL extension for Genetic Constructor - https://github.com/autodesk-bionano/genome-designer/tree/master/extensions/gslEditor 

Thanks!
